### PR TITLE
Fix highlighting of string interpolation after escape

### DIFF
--- a/syntaxes/packer.json
+++ b/syntaxes/packer.json
@@ -698,11 +698,11 @@
     },
     "string_interpolation": {
       "name": "meta.interpolation.hcl",
-      "begin": "(\\G|[^%$])([%$]{)",
+      "begin": "(?<![%$])([%$]{)",
       "end": "\\}",
       "comment": "String interpolation",
       "beginCaptures": {
-        "2": {
+        "1": {
           "name": "keyword.other.interpolation.begin.hcl"
         }
       },


### PR DESCRIPTION
Currently, when you put a escape character before a string intepolation expression in a string, the interpolation is not highlighted:

![image](https://github.com/mondeja/vscode-packer-powertools/assets/23049315/67f8d900-9a9c-4151-915a-fc59c679c1a3)

After this patch, is working as expected:

![image](https://github.com/mondeja/vscode-packer-powertools/assets/23049315/de074a24-85a9-401c-b6ff-4315cbff4016)

Check [`hashicorp.terraform`](https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform) extension syntax, is using this approach.